### PR TITLE
Add CLI flag for legacy dataset output format

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { createReadStream, createWriteStream, promises as fs } from "node:fs";
 import { createInterface } from "node:readline";
-import { resolve } from "node:path";
+import { basename, dirname, extname, resolve } from "node:path";
 import { countNonEmptyLines, ProgressBar } from "./progress.js";
 import { loadConfigRawArgs } from "./config.js";
 import {
@@ -122,6 +122,7 @@ export type Args = {
   model: string;
   promptsPath: string;
   outPath: string;
+  datasetReadmePath: string | null;
   apiBase: string;
   systemPrompt: string;
   storeSystem: boolean;
@@ -296,6 +297,10 @@ function parseArgsFromRaw(args: Record<string, string | boolean>): Args {
   const model = (args.model as string) || "";
   const promptsPath = (args.prompts as string) || "";
   const outPath = (args.out as string) || "dataset.jsonl";
+  const datasetReadmePath = resolveDatasetReadmePath(
+    args["dataset-readme"] ?? args.datasetReadme,
+    outPath
+  );
   const apiBase = (args.api as string) || "https://openrouter.ai/api/v1";
   const systemPrompt = (args.system as string) || "";
   const storeSystemRaw = args["store-system"];
@@ -377,6 +382,7 @@ function parseArgsFromRaw(args: Record<string, string | boolean>): Args {
     model,
     promptsPath,
     outPath,
+    datasetReadmePath,
     apiBase,
     systemPrompt,
     storeSystem,
@@ -427,12 +433,6 @@ export function buildRequestMessages(
     : [{ role: "user" as const, content: userPrompt }];
 }
 
-export function formatAssistantContent(content: string, reasoning?: string) {
-  return typeof reasoning === "string" && reasoning.trim().length > 0
-    ? `<think>${reasoning}</think>\n${content}`
-    : content;
-}
-
 export function buildOutputMessages(
   systemPrompt: string,
   userPrompt: string,
@@ -447,12 +447,12 @@ export function buildOutputMessages(
     return [
       { role: "system" as const, content: systemPrompt },
       { role: "user" as const, content: userPrompt },
-      { role: "assistant" as const, content: assistantContent }
+      assistantMessage
     ];
   }
   return [
     { role: "user" as const, content: userPrompt },
-    { role: "assistant" as const, content: assistantContent }
+    assistantMessage
   ];
 }
 
@@ -582,6 +582,7 @@ export async function main(argv = process.argv.slice(2)) {
     model,
     promptsPath,
     outPath,
+    datasetReadmePath,
     apiBase,
     systemPrompt,
     storeSystem,
@@ -837,7 +838,6 @@ export async function main(argv = process.argv.slice(2)) {
           spentUsd += calculateOpenRouterSpendUSD(pricing, usage);
         }
 
-        const assistantContent = formatAssistantContent(content, reasoning);
         const messages = buildOutputMessages(
           systemPrompt,
           prompt,

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,7 @@ const HELP_TEXT = [
   "  --openrouter.provider <slugs>   OpenRouter provider slugs (comma-separated list).",
   "  --openrouter.providerSort <x>   Provider sorting order (price|throughput|latency).",
   "  --reasoningEffort <level>       Reasoning effort (none|minimal|low|medium|high|xhigh).",
+  "  --save-old-format               Store assistant reasoning in legacy <think> tags inside content.",
   "  --dataset-readme [file]         Generate a dataset README template next to the output JSONL or at a custom path.",
   "  --timeout <ms>                  Request timeout in milliseconds.",
   "  --no-progress                   Disable the progress bar.",
@@ -131,6 +132,7 @@ export type Args = {
   openrouterProviderSort: string | null;
   openrouterIsFree: boolean;
   reasoningEffort: string | null;
+  saveOldFormat: boolean;
   timeout: number | null;
 };
 
@@ -201,6 +203,11 @@ export function formatAssistantContent(content: string, reasoning?: string) {
   return normalizedReasoning ? { content, thinking: normalizedReasoning } : { content };
 }
 
+export function formatAssistantContentOld(content: string, reasoning?: string) {
+  const normalizedReasoning = normalizeReasoning(reasoning);
+  return normalizedReasoning ? `<think>${normalizedReasoning}</think>\n${content}` : content;
+}
+
 export function generateDatasetReadmeTemplate(input: {
   model: string;
   apiBase: string;
@@ -209,22 +216,29 @@ export function generateDatasetReadmeTemplate(input: {
   systemPrompt: string;
   storeSystem: boolean;
   reasoningEffort: string | null;
+  saveOldFormat: boolean;
 }) {
   const datasetName = deriveDatasetName(input.outPath);
+  const assistantExample = input.saveOldFormat
+    ? { role: "assistant", content: "<think>...</think>\n..." }
+    : { role: "assistant", thinking: "...", content: "..." };
   const exampleMessages = input.storeSystem && input.systemPrompt.trim().length > 0
     ? [
         { role: "system", content: input.systemPrompt },
         { role: "user", content: "..." },
-        { role: "assistant", thinking: "...", content: "..." }
+        assistantExample
       ]
     : [
         { role: "user", content: "..." },
-        { role: "assistant", thinking: "...", content: "..." }
+        assistantExample
       ];
   const example = JSON.stringify({ messages: exampleMessages }, null, 2);
   const reasoningLine = input.reasoningEffort
     ? `- Reasoning effort: \`${input.reasoningEffort}\``
     : "- Reasoning effort: not set";
+  const assistantFormatLine = input.saveOldFormat
+    ? "Assistant reasoning is embedded in assistant `content` using legacy `<think>` tags when present."
+    : "Assistant reasoning is stored in a separate `thinking` field when present.";
 
   return [
     "---",
@@ -258,7 +272,7 @@ export function generateDatasetReadmeTemplate(input: {
     "## Format",
     "",
     "Each line is a JSON object with a `messages` array.",
-    "Assistant reasoning is stored in a separate `thinking` field when present.",
+    assistantFormatLine,
     "",
     "## Example",
     "",
@@ -269,8 +283,14 @@ export function generateDatasetReadmeTemplate(input: {
   ].join("\n");
 }
 
-export function buildAssistantMessage(content: string, reasoning?: string) {
-  return { role: "assistant" as const, ...formatAssistantContent(content, reasoning) };
+export function buildAssistantMessage(
+  content: string,
+  reasoning?: string,
+  saveOldFormat = false
+) {
+  return saveOldFormat
+    ? { role: "assistant" as const, content: formatAssistantContentOld(content, reasoning) }
+    : { role: "assistant" as const, ...formatAssistantContent(content, reasoning) };
 }
 
 function parseArgsFromRaw(args: Record<string, string | boolean>): Args {
@@ -336,6 +356,14 @@ function parseArgsFromRaw(args: Record<string, string | boolean>): Args {
       ? reasoningEffortRaw.trim()
       : null;
 
+  const saveOldFormatRaw = args["save-old-format"];
+  const saveOldFormat =
+    saveOldFormatRaw === undefined
+      ? false
+      : typeof saveOldFormatRaw === "boolean"
+        ? saveOldFormatRaw
+        : String(saveOldFormatRaw).toLowerCase() !== "false";
+
   const timeoutRaw = args.timeout;
   const timeoutParsed =
     timeoutRaw === undefined ? null : Math.floor(Number(timeoutRaw));
@@ -346,7 +374,7 @@ function parseArgsFromRaw(args: Record<string, string | boolean>): Args {
 
   if (!model || !promptsPath) {
     throw new Error(
-      `${USAGE_LINE} [--out dataset.jsonl] [--api https://openrouter.ai/api/v1] [--system "..."] [--store-system true|false] [--concurrent 1] [--openrouter.isFree true|false] [--openrouter.provider openai,anthropic] [--openrouter.providerSort price|throughput|latency] [--reasoningEffort low|medium|high] [--timeout <ms>] [--no-progress]`
+      `${USAGE_LINE} [--out dataset.jsonl] [--api https://openrouter.ai/api/v1] [--system "..."] [--store-system true|false] [--concurrent 1] [--openrouter.isFree true|false] [--openrouter.provider openai,anthropic] [--openrouter.providerSort price|throughput|latency] [--reasoningEffort low|medium|high] [--save-old-format] [--timeout <ms>] [--no-progress]`
     );
   }
 
@@ -364,6 +392,7 @@ function parseArgsFromRaw(args: Record<string, string | boolean>): Args {
     openrouterProviderSort,
     openrouterIsFree,
     reasoningEffort,
+    saveOldFormat,
     timeout
   };
 }
@@ -382,7 +411,12 @@ export function parseArgs(argv: string[]): Args {
   const merged =
     configPath
       ? { ...loadConfigRawArgs(configPath), ...cliRaw }
-      : cliRaw;
+      : { ...cliRaw };
+
+  delete merged["save-old-format"];
+  if (cliRaw["save-old-format"] !== undefined) {
+    merged["save-old-format"] = cliRaw["save-old-format"];
+  }
 
   return parseArgsFromRaw(merged);
 }
@@ -404,9 +438,10 @@ export function buildOutputMessages(
   userPrompt: string,
   assistantContent: string,
   storeSystem: boolean,
-  reasoning?: string
+  reasoning?: string,
+  saveOldFormat = false
 ) {
-  const assistantMessage = buildAssistantMessage(assistantContent, reasoning);
+  const assistantMessage = buildAssistantMessage(assistantContent, reasoning, saveOldFormat);
   const hasSystem = systemPrompt.trim().length > 0;
   if (hasSystem && storeSystem) {
     return [
@@ -557,6 +592,7 @@ export async function main(argv = process.argv.slice(2)) {
     openrouterProviderSort,
     openrouterIsFree,
     reasoningEffort,
+    saveOldFormat,
     timeout
   } = parsed;
 
@@ -807,7 +843,8 @@ export async function main(argv = process.argv.slice(2)) {
           prompt,
           content,
           storeSystem,
-          reasoning
+          reasoning,
+          saveOldFormat
         );
 
         await writeJsonlLine(JSON.stringify({ messages }) + "\n");
@@ -865,7 +902,8 @@ export async function main(argv = process.argv.slice(2)) {
       rowCount: okCount,
       systemPrompt,
       storeSystem,
-      reasoningEffort
+      reasoningEffort,
+      saveOldFormat
     });
     await fs.writeFile(datasetReadmePath, template, "utf8");
     writeLine(`Wrote dataset README template to ${datasetReadmePath}`);

--- a/test/datagen.test.ts
+++ b/test/datagen.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -12,7 +12,8 @@ import {
   generateDatasetReadmeTemplate,
   resolveDatasetReadmePath,
   callOpenRouter,
-  ensureReadableFile
+  ensureReadableFile,
+  main
 } from "../src/index.js";
 
 test("parseArgs requires model and prompts", () => {
@@ -411,6 +412,115 @@ test("callOpenRouter reasoning.effort works for non-OpenRouter apiBase", async (
   assert.equal(calls.length, 1);
   const body = JSON.parse(calls[0].init.body);
   assert.deepEqual(body.reasoning, { effort: "minimal" });
+});
+
+test("main writes new assistant format by default", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "datagen-"));
+  const promptsPath = join(dir, "prompts.txt");
+  const outPath = join(dir, "dataset.jsonl");
+  await writeFile(promptsPath, "hello\n");
+
+  const originalApiKey = process.env.API_KEY;
+  process.env.API_KEY = "KEY";
+
+  globalThis.fetch = async () =>
+    ({
+      ok: true,
+      status: 200,
+      async json() {
+        return {
+          choices: [
+            {
+              message: {
+                content: "answer",
+                reasoning: "reasoning here"
+              }
+            }
+          ]
+        };
+      }
+    }) as any;
+
+  try {
+    await main([
+      "--model",
+      "model-x",
+      "--prompts",
+      promptsPath,
+      "--out",
+      outPath,
+      "--api",
+      "https://example.com/api/v1",
+      "--no-progress"
+    ]);
+  } finally {
+    process.env.API_KEY = originalApiKey;
+  }
+
+  const output = await readFile(outPath, "utf8");
+  assert.equal(output.trim().length > 0, true);
+  const row = JSON.parse(output.trim());
+  assert.deepEqual(row, {
+    messages: [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "answer", thinking: "reasoning here" }
+    ]
+  });
+});
+
+test("main writes legacy assistant format with --save-old-format", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "datagen-"));
+  const promptsPath = join(dir, "prompts.txt");
+  const outPath = join(dir, "dataset.jsonl");
+  await writeFile(promptsPath, "hello\n");
+
+  const originalApiKey = process.env.API_KEY;
+  process.env.API_KEY = "KEY";
+
+  globalThis.fetch = async () =>
+    ({
+      ok: true,
+      status: 200,
+      async json() {
+        return {
+          choices: [
+            {
+              message: {
+                content: "answer",
+                reasoning: "reasoning here"
+              }
+            }
+          ]
+        };
+      }
+    }) as any;
+
+  try {
+    await main([
+      "--model",
+      "model-x",
+      "--prompts",
+      promptsPath,
+      "--out",
+      outPath,
+      "--api",
+      "https://example.com/api/v1",
+      "--save-old-format",
+      "--no-progress"
+    ]);
+  } finally {
+    process.env.API_KEY = originalApiKey;
+  }
+
+  const output = await readFile(outPath, "utf8");
+  assert.equal(output.trim().length > 0, true);
+  const row = JSON.parse(output.trim());
+  assert.deepEqual(row, {
+    messages: [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "<think>reasoning here</think>\nanswer" }
+    ]
+  });
 });
 
 test("ensureReadableFile throws if missing or not a file", async () => {

--- a/test/datagen.test.ts
+++ b/test/datagen.test.ts
@@ -8,6 +8,9 @@ import {
   buildRequestMessages,
   buildOutputMessages,
   formatAssistantContent,
+  formatAssistantContentOld,
+  generateDatasetReadmeTemplate,
+  resolveDatasetReadmePath,
   callOpenRouter,
   ensureReadableFile,
   main

--- a/test/datagen.test.ts
+++ b/test/datagen.test.ts
@@ -8,6 +8,7 @@ import {
   buildRequestMessages,
   buildOutputMessages,
   formatAssistantContent,
+  formatAssistantContentOld,
   generateDatasetReadmeTemplate,
   resolveDatasetReadmePath,
   callOpenRouter,
@@ -61,6 +62,17 @@ test("parseArgs parses --reasoningEffort", () => {
     "high"
   ]);
   assert.equal(args.reasoningEffort, "high");
+});
+
+test("parseArgs parses --save-old-format from CLI", () => {
+  const args = parseArgs([
+    "--model",
+    "m",
+    "--prompts",
+    "p.txt",
+    "--save-old-format"
+  ]);
+  assert.equal(args.saveOldFormat, true);
 });
 
 test("parseArgs parses --dataset-readme", () => {
@@ -127,6 +139,7 @@ test("parseArgs supports --config YAML", async () => {
   assert.equal(args.openrouterProviderSort, "throughput");
   assert.equal(args.reasoningEffort, "high");
   assert.equal(args.progress, false);
+  assert.equal(args.saveOldFormat, false);
 });
 
 test("parseArgs lets CLI override config", async () => {
@@ -136,6 +149,21 @@ test("parseArgs lets CLI override config", async () => {
   const args = parseArgs(["--config", configPath, "--model", "b"]);
   assert.equal(args.model, "b");
   assert.equal(args.promptsPath, "p.txt");
+});
+
+test("parseArgs ignores save-old-format in config and only honors CLI", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "datagen-"));
+  const configPath = join(dir, "config.yaml");
+  await writeFile(
+    configPath,
+    ["model: a", "prompts: p.txt", "save-old-format: true", ""].join("\n")
+  );
+
+  const fromConfigOnly = parseArgs(["--config", configPath]);
+  assert.equal(fromConfigOnly.saveOldFormat, false);
+
+  const fromCli = parseArgs(["--config", configPath, "--save-old-format"]);
+  assert.equal(fromCli.saveOldFormat, true);
 });
 
 test("resolveDatasetReadmePath handles booleans and custom paths", () => {
@@ -170,12 +198,26 @@ test("formatAssistantContent stores reasoning in thinking", () => {
   assert.deepEqual(out, { content: "answer", thinking: "reasoning here" });
 });
 
+test("formatAssistantContentOld wraps reasoning in <think>", () => {
+  const out = formatAssistantContentOld("answer", "reasoning here");
+  assert.equal(out, "<think>reasoning here</think>\nanswer");
+});
+
 test("buildOutputMessages includes thinking when present", () => {
   const messages = buildOutputMessages("sys", "u", "a", true, "reasoning here");
   assert.deepEqual(messages, [
     { role: "system", content: "sys" },
     { role: "user", content: "u" },
     { role: "assistant", content: "a", thinking: "reasoning here" }
+  ]);
+});
+
+test("buildOutputMessages uses legacy assistant format when requested", () => {
+  const messages = buildOutputMessages("sys", "u", "a", true, "reasoning here", true);
+  assert.deepEqual(messages, [
+    { role: "system", content: "sys" },
+    { role: "user", content: "u" },
+    { role: "assistant", content: "<think>reasoning here</think>\na" }
   ]);
 });
 
@@ -187,11 +229,27 @@ test("generateDatasetReadmeTemplate reflects the aligned chat format", () => {
     rowCount: 887,
     systemPrompt: "You are a helpful assistant",
     storeSystem: true,
-    reasoningEffort: "high"
+    reasoningEffort: "high",
+    saveOldFormat: false
   });
   assert.match(readme, /Assistant reasoning is stored in a separate `thinking` field/);
   assert.match(readme, /"thinking": "\.\.\."/);
   assert.match(readme, /Rows: 887/);
+});
+
+test("generateDatasetReadmeTemplate reflects the legacy assistant format", () => {
+  const readme = generateDatasetReadmeTemplate({
+    model: "openai/gpt-4o-mini",
+    apiBase: "https://openrouter.ai/api/v1",
+    outPath: "/tmp/my_dataset.jsonl",
+    rowCount: 887,
+    systemPrompt: "You are a helpful assistant",
+    storeSystem: true,
+    reasoningEffort: "high",
+    saveOldFormat: true
+  });
+  assert.match(readme, /legacy `<think>` tags/);
+  assert.match(readme, /<think>\.\.\.<\/think>\\n\.\.\./);
 });
 
 test("callOpenRouter sends correct payload and parses reasoning", async () => {


### PR DESCRIPTION
## Summary
- add `--save-old-format` to keep backward compatibility as an explicit CLI-only option
- keep the new `thinking` field format as the default output path
- update message formatting and generated dataset README content to reflect the selected format
- add tests covering CLI parsing, config-file exclusion, legacy formatting, and README examples

## Testing
- `npm test`